### PR TITLE
Turkish translation

### DIFF
--- a/src/Concerto/PanelBundle/Resources/translations/TestWizard.tr_TR.yml
+++ b/src/Concerto/PanelBundle/Resources/translations/TestWizard.tr_TR.yml
@@ -135,6 +135,22 @@ param:
             group.tooltip: Parametre grup alanlarını tanımlayınız
             list: "{0} - liste öğe türlerini tanımla"
             list.tooltip: Parametre liste öğe türlerini tanımlayınız
+            single_line: "{0} - set default value"
+            single_line.tooltip: Parameter default value
+            multi_line: "{0} - set default value"
+            multi_line.tooltip: Parameter default value
+            html: "{0} - set default value"
+            html.tooltip: Parameter default value
+            checkbox: "{0} - set default value"
+            checkbox.tooltip: Parameter default value
+            test: "{0} - set default value"
+            test.tooltip: Parameter default value
+            table: "{0} - set default value"
+            table.tooltip: Parameter default value
+            template: "{0} - set default value"
+            template.tooltip: Parameter default value
+            r_code: "{0} - set default value"
+            r_code.tooltip: Parameter default value
         summaries:
             select: "Seçenek sayısı: {0}"
             group: "Alan sayısı: {0}"
@@ -169,6 +185,7 @@ param:
             group.tooltip: Grup alanları parametresini ayarlayın
             list: "{0} - öğe listesi"
             list.tooltip: Öğe listesi parametresini ayarlayın
+            r: "{0} - R kodu"
         summaries:
             textarea: "{0}"
             html: "{0}"

--- a/src/Concerto/PanelBundle/Resources/translations/TestWizard.tr_TR.yml
+++ b/src/Concerto/PanelBundle/Resources/translations/TestWizard.tr_TR.yml
@@ -92,6 +92,7 @@ param:
             type.single_line_text: Tek satır metin
             type.multi_line_text: Çok satırlı metin
             type.html: HTML
+            type.r: R kodu
             type.select: Aşağı açılır liste
             type.view: Şablonu göster
             type.test: Test
@@ -135,26 +136,30 @@ param:
             group.tooltip: Parametre grup alanlarını tanımlayınız
             list: "{0} - liste öğe türlerini tanımla"
             list.tooltip: Parametre liste öğe türlerini tanımlayınız
-            single_line: "{0} - set default value"
-            single_line.tooltip: Parameter default value
-            multi_line: "{0} - set default value"
-            multi_line.tooltip: Parameter default value
-            html: "{0} - set default value"
-            html.tooltip: Parameter default value
-            checkbox: "{0} - set default value"
-            checkbox.tooltip: Parameter default value
-            test: "{0} - set default value"
-            test.tooltip: Parameter default value
-            table: "{0} - set default value"
-            table.tooltip: Parameter default value
-            template: "{0} - set default value"
-            template.tooltip: Parameter default value
-            r_code: "{0} - set default value"
-            r_code.tooltip: Parameter default value
+            single_line: "{0} - varsayılan değer"
+            single_line.tooltip: Parametre varsayılan değeri
+            multi_line: "{0} - varsayılan değer"
+            multi_line.tooltip: Parametre varsayılan değeri
+            html: "{0} - varsayılan değer"
+            html.tooltip: Parametre varsayılan değeri
+            checkbox: "{0} - varsayılan değer"
+            checkbox.tooltip: Parametre varsayılan değeri
+            test: "{0} - varsayılan değer"
+            test.tooltip: Parametre varsayılan değeri
+            table: "{0} - varsayılan değer"
+            table.tooltip: Parametre varsayılan değeri
+            template: "{0} - varsayılan değer"
+            template.tooltip: Parametre varsayılan değeri
+            r_code: "{0} - varsayılan değer"
+            r_code.tooltip: Parametre varsayılan değeri
         summaries:
             select: "Seçenek sayısı: {0}"
             group: "Alan sayısı: {0}"
             list: "Öğre türü: {0}"
+        select.options: Seçenekler
+        select.options.tooltip: Kullanılabilir seçenekleri tanımlar
+        select.default: Varsayılan
+        select.default.tooltip: Varsayılan değeri seç
         select.option.add: Yeni seçenek ekle
         select.option.remove.selected: Seçili seçenekleri sil
         select.option.remove.all: Tüm seçenekleri kaldır
@@ -192,6 +197,7 @@ param:
             column: "Tablo: {0}, Sütun: {1}"
             group: "{0}"
             list: "Öğe sayısı: {0}"
+            r: "{0}"
         column.table: Veri tablosu
         column.table.tooltip: Daha sonra sütunu seçeceğiniz veri tablosunu belirleyin
         column: Sütun

--- a/src/Concerto/TestBundle/Resources/translations/messages.tr_TR.yml
+++ b/src/Concerto/TestBundle/Resources/translations/messages.tr_TR.yml
@@ -1,0 +1,15 @@
+session.resuming: Teste devam et
+session.resuming.question: Teste başladığınızı ancak bitirmediğinizi belirledik. Teste geri dönmek için Tamam'a basın ya da kutucuğu işaretleyip yeniden başlayın.
+session.resuming.start_new_checkbox_label: Testi yeniden başlat
+OK: Tamam
+ignition.noscript: Tarayıcınız Javascript desteklemiyor. Lütfen Javascript'i etkinleştirin ve yeniden deneyin.
+ignition.ip: "IP:"
+ignition.browser: "Tarayıcı:"
+ignition.time: "Zaman:"
+ignition.browser.notsupported: Tarayıcı sürümünüz desteklenmiyor. Lütfen tarayıcınızı Internet Explorer 9 ya da üzerine güncelleyin ya da Chrome ya da Firefox tarayıcılarını kullanın.
+ignition.browser.potentionallynotsupported: Eğer bu mesaj birazdan kaybolmazsa, başka bir tarayıcı kullanmanıza ihtiyaç duyulacaktır.
+default.template:
+    error: Hata oluştu. Çalışma durdu.
+    finished: Test Tamamlandı.
+    loading: Lütfen Bekleyin...
+    unresumable: Test zaman aşımına uğradı. Yeniden başlamak için lütfen tarayıcınızı yenileyin.


### PR DESCRIPTION
Missing parts have been translated. 

There are still missing lines that I cannot find the location regarding column_map in the Testwizard. 

in App available locales: Language selection choice will be "Türkçe" 