### PR TITLE
Fixes an issue with the concerto-ec2-basic-tls CloudFormation configuration

### DIFF
--- a/deploy/cf/concerto-ec2-basic-tls.yml
+++ b/deploy/cf/concerto-ec2-basic-tls.yml
@@ -340,6 +340,7 @@ Resources:
       ResourceSignal:
         Count: 1
         Timeout: PT15M
+    Metadata:
       AWS::CloudFormation::Init:
         configSets:
           default:


### PR DESCRIPTION
The `Metadata` key for the `WebServerInstance` was missing for the concerto-ec2-basic-tls configuration. Consequently, CloudFormation stack creation would stop and complain about an invalid property when attempting to create the web server resource. Users who attempt to follow the QuickStart guide will be unable to successfully follow along and generate a stack.