### PR TITLE
Enforcing UTF8 encoding when connecting to the MySQL server

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -68,6 +68,8 @@ doctrine:
                 charset:     UTF8
                 path:        "%database_path%"
                 unix_socket: "%database_unix_socket%"
+                options:
+                    1002: "SET NAMES 'UTF8'"
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"


### PR DESCRIPTION
Addressing issue https://github.com/campsych/concerto-platform/issues/294.

'1002' refers to the constant PDO::MYSQL_ATTR_INIT_COMMAND. This commit enforces UTF8 when a connection to the MySQL server is made.