### PR TITLE
Adding Backtickets to groups to not be confused with mysql keyword

### DIFF
--- a/src/Concerto/PanelBundle/Entity/ATopEntity.php
+++ b/src/Concerto/PanelBundle/Entity/ATopEntity.php
@@ -42,7 +42,7 @@ abstract class ATopEntity extends AEntity
     /**
      *
      * @var groups
-     * @ORM\Column(type="string")
+     * @ORM\Column(name="`groups`", type="string")
      */
     protected $groups;
 


### PR DESCRIPTION
This pull request try to address issues found at:

#308 
#318 

In this solution, backticks are used to prevent issues with the reserved keyword "group" in MySQL.

If you are upgrading from MySQL 5.7 to MySQL 8.0, you may encounter problems with the authentication system. One solution is to add the line "default-authentication-plugin=mysql_native_password" to your MySQL configuration settings. 

Please note that I did not include this solution in the pull request.