### PR TITLE
Add IPv6 support to TestSession

### DIFF
--- a/src/Concerto/PanelBundle/Entity/TestSession.php
+++ b/src/Concerto/PanelBundle/Entity/TestSession.php
@@ -79,7 +79,7 @@ class TestSession
 
     /**
      *
-     * @ORM\Column(type="string", length=15, nullable=true)
+     * @ORM\Column(type="string", length=45, nullable=true)
      */
     private $clientIp;
 


### PR DESCRIPTION
Solves issue https://github.com/campsych/concerto-platform/issues/380#issue-2740579448
The $clientIp field was only made for IPv4, and application failed with when client connected with IPv6. I Increased the length of the field to fit maximum length of IPv6 addresses.
